### PR TITLE
Fix entity list type

### DIFF
--- a/src/CellMLToolkit.jl
+++ b/src/CellMLToolkit.jl
@@ -45,8 +45,8 @@ import ModelingToolkit.ODEProblem
     ODEProblem constructs an ODEProblem from a CellModel
 """
 function ODEProblem(ml::CellModel, tspan;
-                    jac = false, level = 1, p = last.(list_params(ml)),
-                    u0 = last.(list_states(ml)))
+                    jac = false, level = 1, p = list_params(ml),
+                    u0 = list_states(ml))
     ODEProblem(ml.sys, u0, tspan, p; jac = jac)
 end
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -317,7 +317,7 @@ function find_list_value(doc::Document, names)
     varkeys = Set(keys(vars))
     groups = find_equivalence_groups(doc)
 
-    vals = []
+    vals = Pair{Num, Float64}[]
 
     for x in names
         u = split_sym(x)


### PR DESCRIPTION
Addresses #93 , which is basically caused by `list_params` and `list_states` returning a vector with entries of type any instead of a concrete type.