### PR TITLE
Update to ModelingToolkit 11 and SymbolicUtils 4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CellMLToolkit"
 uuid = "03cb29e0-1ef4-4721-aa24-cf58a006576f"
 authors = ["Shahriar Iravanian <siravan@svtsim.com>"]
-version = "3.0.0"
+version = "2.16.0"
 
 [deps]
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CellMLToolkit"
 uuid = "03cb29e0-1ef4-4721-aa24-cf58a006576f"
 authors = ["Shahriar Iravanian <siravan@svtsim.com>"]
-version = "2.15.0"
+version = "3.0.0"
 
 [deps]
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
@@ -14,13 +14,13 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 [compat]
 Aqua = "0.8"
 EzXML = "1.1"
-MathML = "0.1.16"
+MathML = "0.1.19"
 Memoize = "0.4.2"
-ModelingToolkit = "10"
+ModelingToolkit = "11.21"
 OrdinaryDiffEq = "6.103"
 SafeTestsets = "0.1"
 Setfield = "1.1.1"
-SymbolicUtils = "3, 4"
+SymbolicUtils = "4"
 Test = "1.10"
 julia = "1.10"
 

--- a/src/CellMLToolkit.jl
+++ b/src/CellMLToolkit.jl
@@ -3,11 +3,11 @@ module CellMLToolkit
 using EzXML: EzXML, elements, namespace, nodecontent, parentnode, readxml, root
 using MathML: extract_mathml, parse_node
 using Memoize: @memoize
-using SymbolicUtils: operation
+using SymbolicUtils: SymbolicUtils, operation
 using ModelingToolkit: ModelingToolkit, @parameters, @variables, Differential,
     Equation, ODEProblem, System,
     Symbolics, equations, parameters, mtkcompile,
-    substitute, unknowns
+    substitute, unknowns, initial_conditions
 using Setfield: @set!
 
 include("structures.jl")

--- a/src/components.jl
+++ b/src/components.jl
@@ -210,7 +210,23 @@ end
 
 ##############################################################################
 
-substitute_eqs(eqs, s) = [substitute(eq.lhs, s) ~ substitute(eq.rhs, s) for eq in eqs]
+function _substitute_expr(expr, d)
+    result = substitute(expr, d)
+    # SymbolicUtils 4 doesn't descend into Differential arguments,
+    # so manually substitute inside them
+    if SymbolicUtils.iscall(result) && operation(result) isa Differential
+        diff_op = operation(result)
+        args = SymbolicUtils.arguments(result)
+        new_args = [substitute(a, d) for a in args]
+        result = diff_op(new_args...)
+    end
+    return result
+end
+
+function substitute_eqs(eqs, s)
+    d = Dict(s)
+    return [_substitute_expr(eq.lhs, d) ~ _substitute_expr(eq.rhs, d) for eq in eqs]
+end
 
 """
     process_components is the main entry point
@@ -240,8 +256,8 @@ function process_components(doc::Document; simplify = true)
         # Defaults need to be set after simplifying as otherwise parameters and
         # states for which no defaults are available may still be present in
         # the system
-        @set! sys.defaults = merge(
-            ModelingToolkit.defaults(sys),
+        @set! sys.initial_conditions = merge(
+            Dict{Any, Any}(initial_conditions(sys)),
             Dict{Any, Any}(find_list_value(doc, vcat(parameters(sys), unknowns(sys))))
         )
     end
@@ -278,7 +294,8 @@ function process_component(doc::Document, comp, class)
         eqs = vcat(parse_node.(math)...)
         eqs = substitute_eqs(eqs, pre_sub)
         sub_rhs = remove_rhs_diff(eqs)
-        eqs = Equation[eq.lhs ~ substitute(eq.rhs, sub_rhs) for eq in eqs]
+        sub_rhs_dict = Dict(sub_rhs)
+        eqs = Equation[eq.lhs ~ substitute(eq.rhs, sub_rhs_dict) for eq in eqs]
     end
 
     ivₚ = get_ivₚ(doc)

--- a/test/beeler.jl
+++ b/test/beeler.jl
@@ -23,7 +23,7 @@ err = sum(abs.(V1 .- V2)) / length(V1)
 
 # Ensure defaults are set and that generating an `ODEProblem` directly from the
 # `ODESystem` is equivalent to doing so from a `CellModel`
-@test length(ModelingToolkit.defaults(ml.sys)) > 0
+@test length(ModelingToolkit.initial_conditions(ml.sys)) > 0
 sys_prob = ODEProblem(ml.sys, nothing, (0, 10000.0))
 sol3 = solve(prob, Euler(), dt = 0.01, saveat = 1.0)
 V3 = map(x -> x[1], sol3.u)

--- a/test/noble_1962.jl
+++ b/test/noble_1962.jl
@@ -14,7 +14,7 @@ err1 = sum(abs.(V1 .- V2)) / length(V1)
 
 # Ensure defaults are set and that generating an `ODEProblem` directly from the
 # `ODESystem` is equivalent to doing so from a `CellModel`
-@test length(ModelingToolkit.defaults(ml.sys)) > 0
+@test length(ModelingToolkit.initial_conditions(ml.sys)) > 0
 sys_prob = ODEProblem(ml.sys, nothing, (0, 10000.0))
 sol3 = solve(prob, Euler(), dt = 0.01, saveat = 1.0)
 V3 = map(x -> x[2], sol3.u)


### PR DESCRIPTION
## Summary
- Updates CellMLToolkit to work with ModelingToolkit 11.21 and SymbolicUtils 4
- Replaces `ModelingToolkit.defaults` with `initial_conditions` (removed in MTK 11)
- Fixes `substitute` calls to use `Dict` instead of `Vector{Pair}` (required by SymbolicUtils 4)
- Adds `_substitute_expr` helper to manually substitute inside `Differential` arguments, which `substitute` in SymbolicUtils 4 no longer handles
- Bumps version to 3.0.0 (breaking: drops MTK 10 support)
- Requires MathML >= 0.1.19 for Symbolics 7 compat (see SciML/MathML.jl#93)

Supersedes #171 (dependabot PR that only bumped the compat bound without handling the breaking API changes).

## Dependencies
- SciML/MathML.jl#93 must be merged and registered first (bumps MathML to 0.1.19 with Symbolics 7 compat)

## Test plan
- [x] All tests pass locally with MTK 11.21.0
- [x] Runic formatting check passes
- [ ] CI passes (blocked on MathML 0.1.19 registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)