### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -20,6 +20,5 @@ jobs:
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       group: "${{ matrix.group }}"
-      julia-version: "1.10"
-      skip: "Pkg,TOML"
+      julia-version: "lts"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,12 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
 jobs:
-  TagBot:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-            token: ${{ secrets.GITHUB_TOKEN }}
-            ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR applies the canonical SciML CI cleanup. This is not a monorepo (no `lib/` subpackages), so no TagBot subpackage matrix is needed.

- TagBot.yml: replaced the inlined `JuliaRegistries/TagBot@v1` job (was a `schedule`-triggered cron with hand-rolled steps) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1`.
- Downgrade.yml: removed `skip: "Pkg,TOML"` (stdlibs, auto-populated centrally); changed `julia-version: "1.10"` -> "lts".

Static verification only: edited YAML parses cleanly. No instantiate/precompile/tests were run.

Ignore until reviewed by @ChrisRackauckas.