### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -13,24 +13,6 @@ on:
   schedule:
     - cron: '48 8 * * 5'
 jobs:
-  test:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Core
-          - QA
-        version:
-          - '1'
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
-      os: "${{ matrix.os }}"
-      julia-runtest-depwarn: "error"
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,7 @@
+[Core]
+versions = ["1"]
+os = ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+[QA]
+versions = ["1"]
+os = ["ubuntu-latest", "macos-latest", "windows-latest"]


### PR DESCRIPTION
## Summary

Converts the root test workflow to the canonical SciML CI pattern: the
`.github/workflows/Tests.yml` (`name: CI`) test job is replaced by a thin
caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, and the
group × version × OS matrix is declared once in a new root
`test/test_groups.toml`.

This repo is already Category A — `test/runtests.jl` dispatches on the
standard `GROUP` env var into `Core` and `QA` groups (`QA` runs `qa.jl`'s
Aqua suite). So no `runtests.jl` change and no `group-env-name` input are
needed.

### Workflow change

The old job hand-maintained a `group × version × os` matrix calling
`tests.yml@v1`. It is replaced with:

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    secrets: "inherit"
```

The filename (`Tests.yml`) and `name: CI` are preserved so branch-protection
status checks are unaffected. The `on:` triggers (push/PR on `master` with
`paths-ignore: docs/**`, plus the weekly `schedule` cron) are preserved
verbatim. There was no `concurrency:` block to preserve.

No `with:` inputs are added: the old job used `check-bounds` default (`yes`),
default coverage, no apt-packages, and the standard `GROUP` env var — all of
which match the `grouped-tests.yml@v1` defaults.

### Matrix declaration (`test/test_groups.toml`)

```toml
[Core]
versions = ["1"]
os = ["ubuntu-latest", "macos-latest", "windows-latest"]

[QA]
versions = ["1"]
os = ["ubuntu-latest", "macos-latest", "windows-latest"]
```

### Matrix match

`scripts/compute_affected_sublibraries.jl . --root-matrix` emits exactly the
6 cells the old workflow ran — **6/6 exact**:

| group | version | os |
|-------|---------|----|
| Core | 1 | ubuntu-latest |
| Core | 1 | macos-latest |
| Core | 1 | windows-latest |
| QA | 1 | ubuntu-latest |
| QA | 1 | macos-latest |
| QA | 1 | windows-latest |

The previous matrix only used Julia version `1` for both groups (no `lts`,
no `pre`); this is reproduced exactly rather than expanded.

### Behavioral note

The old job passed `julia-runtest-depwarn: "error"` to `tests.yml`. The
`grouped-tests.yml@v1` reusable workflow does not expose a depwarn input, so
this thin caller cannot forward it; depwarn reverts to the reusable
workflow's default (`yes`). This is an unavoidable difference of adopting the
canonical caller, not a deliberate relaxation. If strict-depwarn CI is
desired, a depwarn passthrough input would need to be added to
`grouped-tests.yml` upstream.

### QA

QA group already exists (Aqua via `qa.jl`); no local Aqua run was performed
per the Category A static-verify-only path. TOML and YAML both parse cleanly.

Ignore until reviewed by @ChrisRackauckas.