### PR TITLE
Release prep: bump CellMLToolkit to 2.17.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CellMLToolkit"
 uuid = "03cb29e0-1ef4-4721-aa24-cf58a006576f"
 authors = ["Shahriar Iravanian <siravan@svtsim.com>"]
-version = "2.17.2"
+version = "2.17.3"
 
 [deps]
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test-scaffolding changes since 2.17.2 (no functional or public-API changes).