### PR TITLE
Bump CellMLToolkit to v2.17.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CellMLToolkit"
 uuid = "03cb29e0-1ef4-4721-aa24-cf58a006576f"
 authors = ["Shahriar Iravanian <siravan@svtsim.com>"]
-version = "2.17.3"
+version = "2.17.4"
 
 [deps]
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"


### PR DESCRIPTION
Bumps `CellMLToolkit` **v2.17.3 → v2.17.4** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Migrate QA to SciMLTesting 2.4 (#191) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)