### PR TITLE
Require strict SciMLTesting 2.4 QA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CellMLToolkit"
 uuid = "03cb29e0-1ef4-4721-aa24-cf58a006576f"
 authors = ["Shahriar Iravanian <siravan@svtsim.com>"]
-version = "2.17.4"
+version = "3.0.0"
 
 [deps]
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,9 @@
 [deps]
 CellMLToolkit = "03cb29e0-1ef4-4721-aa24-cf58a006576f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
 CellMLToolkit = "3"
 Documenter = "1"
+ModelingToolkit = "11.21"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,5 +3,5 @@ CellMLToolkit = "03cb29e0-1ef4-4721-aa24-cf58a006576f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-CellMLToolkit = "2.9"
+CellMLToolkit = "3"
 Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,8 +23,8 @@ mathengine = MathJax3(
 makedocs(
     sitename = "CellMLToolkit.jl",
     authors = "Chris Rackauckas",
-    modules = Module[],
-    clean = true, doctest = false, linkcheck = true,
+    modules = [CellMLToolkit],
+    clean = true, doctest = true, checkdocs = :exports, linkcheck = true,
     linkcheck_ignore = [
         "https://journals.physiology.org/doi/full/10.1152/ajpheart.00794.2003",
     ],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,7 +38,7 @@ Pkg.add("CellMLToolkit")
 ## Example
 
 ```Julia
-  using CellMLToolkit, DifferentialEquations, Plots
+  using CellMLToolkit, DifferentialEquations, ModelingToolkit, Plots
 
   ml = CellModel("models/lorenz.cellml.xml")
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -3,12 +3,12 @@
 The models directory contains a few CellML model examples. Let's start with a simple one, the famous Lorenz equations!
 
 ```Julia
-  using CellMLToolkit
+  using CellMLToolkit, ModelingToolkit
 
   ml = CellModel("models/lorenz.cellml.xml")
 
   tspan = (0, 100.0)
-  prob = ODEProblem(ml, tspan)
+  prob = ModelingToolkit.ODEProblem(ml, tspan)
 ```
 
 Now, `ml` points to a `CellModel` struct that contains the details of the model, and `prob` is an `ODEProblem` ready for integration. We can solve and visualize `prob` as
@@ -31,7 +31,7 @@ Let's look at more complicated examples. The next one is the [ten Tusscher-Noble
 ```Julia
   ml = CellModel("models/tentusscher_noble_noble_panfilov_2004_a.cellml.xml")
   tspan = (0, 5000.0)
-  prob = ODEProblem(ml, tspan)
+  prob = ModelingToolkit.ODEProblem(ml, tspan)
   sol = solve(prob, TRBDF2(), dtmax=1.0)
   V = map(x -> x[1], sol.u)
   plot(sol.t, V)
@@ -39,10 +39,10 @@ Let's look at more complicated examples. The next one is the [ten Tusscher-Noble
 
 ![](assets/ten.png)
 
-We can also enhance the model by asking ModelingToolkit.jl to generate a Jacobian by passing `jac=true` to the `ODEProblem` constructor.
+We can also enhance the model by asking ModelingToolkit.jl to generate a Jacobian by passing `jac=true` to the `ModelingToolkit.ODEProblem` constructor.
 
 ```Julia
-  prob = ODEProblem(ml, tspan; jac=true)  
+  prob = ModelingToolkit.ODEProblem(ml, tspan; jac=true)
 ```
 
 The rest remains the same. For the last example, we chose a complex model to stress the ODE solvers: [the O'Hara-Rudy left ventricular model](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1002061). This model has 49 state variables, is very stiff, and is prone to oscillation. DifferentialEquations.jl has advanced such that an efficient, pure Julia solution to the O'Hara-Rudy model is now possible.
@@ -50,7 +50,7 @@ The rest remains the same. For the last example, we chose a complex model to str
 ```Julia
   ml = CellModel("models/ohara_rudy_cipa_v1_2017.cellml.xml")
   tspan = (0, 5000.0)
-  prob = ODEProblem(ml, tspan);
+  prob = ModelingToolkit.ODEProblem(ml, tspan);
   sol = solve(prob, dtmax=1.0)
   V = map(x -> x[1], sol.u)
   plot(sol.t, V)
@@ -95,11 +95,11 @@ To modify a parameter, we use `update_list!` function. For example, the followin
 update_list!(p, "stim_period", 400.0)
 ```
 
-We need to pass the new `p` to `ODEProblem` constructor as a keyword parameter. The rest of the code remains the same.
+We need to pass the new `p` to `ModelingToolkit.ODEProblem` as a keyword parameter. The rest of the code remains the same.
 
 ```julia
 tspan = (0, 5000.0)
-prob = ODEProblem(ml, tspan; p = p)
+prob = ModelingToolkit.ODEProblem(ml, tspan; p = p)
 sol = solve(prob, TRBDF2(), dtmax = 1.0)
 V = map(x -> x[1], sol.u)
 plot(sol.t, V)
@@ -107,4 +107,4 @@ plot(sol.t, V)
 
 ![](assets/ten_400.png)
 
-`ODEProblem` also accepts a `u0` parameter to change the initial conditions (remember `u0 = list_initial_conditions(ml)`).
+`ModelingToolkit.ODEProblem` also accepts a `u0` parameter to change the initial conditions (remember `u0 = list_initial_conditions(ml)`).

--- a/src/CellMLToolkit.jl
+++ b/src/CellMLToolkit.jl
@@ -1,6 +1,6 @@
 module CellMLToolkit
 
-using EzXML: EzXML, elements, namespace, nodecontent, parentnode, readxml, root
+using EzXML: EzXML, elements, hasroot, namespace, nodecontent, parentnode, readxml, root
 using MathML: extract_mathml, parse_node
 using Memoize: @memoize
 using SymbolicUtils: SymbolicUtils, operation, unwrap
@@ -19,9 +19,19 @@ include("import.jl")
 """
     read_cellml(path::AbstractString, tspan)
 
-Deprecated alias for `ODEProblem(CellModel(path), tspan)`.
+Deprecated alias for `ModelingToolkit.ODEProblem(CellModel(path), tspan)`.
 
-Use `CellModel(path)` and `ODEProblem(ml, tspan)` directly in new code.
+Use `CellModel(path)` and `ModelingToolkit.ODEProblem(ml, tspan)` directly in
+new code.
+
+# Arguments
+
+  - `path`: Path to a CellML XML file.
+  - `tspan`: Two-element time span for the generated ODE problem.
+
+# Returns
+
+The `ODEProblem` constructed from the parsed CellML model.
 """
 function read_cellml(path::AbstractString, tspan)
     Base.depwarn("`read_cellml` is deprecated, use `CellModel` instead.", :read_cellml)
@@ -31,16 +41,24 @@ end
 
 ##############################################################################
 
-export CellModel, ODEProblem
+export CellModel
 export read_cellml
 export list_params, list_states
-export readxml, getsys
+export getsys
 export update_list!
 
 """
     getsys(ml::CellModel)
 
 Return the ModelingToolkit system generated for `ml`.
+
+# Arguments
+
+  - `ml`: A parsed CellML model.
+
+# Returns
+
+The `ModelingToolkit.System` generated from the CellML components in `ml`.
 """
 getsys(ml::CellModel) = ml.sys
 
@@ -52,6 +70,22 @@ Read the CellML model at `path`, resolve imports, and generate a `CellModel`.
 # Arguments
 
   - `path`: Path to a CellML XML file.
+
+# Returns
+
+A `CellModel` containing the parsed CellML document and generated
+`ModelingToolkit.System`.
+
+# Examples
+
+```jldoctest; setup = :(using CellMLToolkit)
+julia> model_path = joinpath(pkgdir(CellMLToolkit), "models", "lorenz.cellml.xml");
+
+julia> model = CellModel(model_path);
+
+julia> !isempty(list_states(model))
+true
+```
 """
 function CellModel(path::AbstractString)
     doc = load_cellml(path)
@@ -65,6 +99,14 @@ Return the parameter default assignments for `ml`.
 
 The returned vector contains `parameter => value` pairs ordered to match the
 parameters in `getsys(ml)`.
+
+# Arguments
+
+  - `ml`: A parsed CellML model.
+
+# Returns
+
+A vector of `parameter => value` pairs.
 """
 list_params(ml::CellModel) = find_sys_p(ml.doc, ml.sys)
 
@@ -75,28 +117,56 @@ Return the initial state assignments for `ml`.
 
 The returned vector contains `state => value` pairs ordered to match the
 unknowns in `getsys(ml)`.
+
+# Arguments
+
+  - `ml`: A parsed CellML model.
+
+# Returns
+
+A vector of `state => value` pairs.
 """
 list_states(ml::CellModel) = find_sys_u0(ml.doc, ml.sys)
 
 import ModelingToolkit.ODEProblem
 
 """
-    ODEProblem(ml::CellModel, tspan; jac = false, level = 1,
+    ModelingToolkit.ODEProblem(ml::CellModel, tspan; jac = false, level = 1,
         p = last.(list_params(ml)), u0 = last.(list_states(ml)))
 
-Construct an `ODEProblem` from a `CellModel`.
+Construct a ModelingToolkit ODE problem from a `CellModel`.
+
+This method extends the public `ModelingToolkit.ODEProblem` interface. Call it
+through `ModelingToolkit.ODEProblem`; CellMLToolkit does not reexport that
+generic function. The method preserves the CellML model's parameter and state
+ordering unless `p` or `u0` is supplied.
 
 # Arguments
 
   - `ml`: Parsed CellML model.
-  - `tspan`: Time span passed to the generated ODE problem.
+  - `tspan`: Two-element time span passed to the generated ODE problem.
 
 # Keywords
 
-  - `jac`: Whether to request Jacobian generation.
-  - `level`: Accepted for compatibility.
+  - `jac`: Whether to request Jacobian generation from ModelingToolkit.
+  - `level`: Retained for backward compatibility and otherwise ignored.
   - `p`: Parameter values ordered like `list_params(ml)`.
   - `u0`: Initial state values ordered like `list_states(ml)`.
+
+# Returns
+
+An `ODEProblem` whose system is `getsys(ml)`.
+
+# Examples
+
+```jldoctest; setup = :(using CellMLToolkit, ModelingToolkit)
+julia> model = CellModel(joinpath(pkgdir(CellMLToolkit), "models", "lorenz.cellml.xml"));
+
+julia> problem = ModelingToolkit.ODEProblem(model, (0.0, 1.0));
+
+julia> problem.f.sys === getsys(model)
+true
+```
 """
 function ODEProblem(
         ml::CellModel, tspan;
@@ -113,10 +183,15 @@ Replace the value paired with `sym` in `l`.
 
 # Arguments
 
-  - `l`: Vector of `variable => value` pairs, such as the output of `list_params`
-    or `list_states`.
+  - `l`: Mutable vector of `variable => value` pairs, such as the output of
+    `list_params` or `list_states`.
   - `sym`: Symbol identifying the variable to update.
   - `val`: Replacement value.
+
+# Returns
+
+The updated pair when `sym` is present in `l`; otherwise emits a warning and
+returns `nothing`.
 """
 function update_list!(l, sym, val)
     i = findfirst(isequal(sym), Symbol.(first.(l)))

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -4,13 +4,12 @@
 #   get_*:          returns a single 'Ezxml(doc).Node'
 #   list_*_names:   returns a list of String
 
-EzXML.root(doc::Document) = root(doc.xmls[1])
+EzXML.root(doc::Document) = root(first(doc.xmls))
 
-cellml_ns(doc::Document) = cellml_ns(doc.xmls[1])
+cellml_ns(doc::Document) = cellml_ns(first(doc.xmls))
 cellml_ns(comp::Component) = cellml_ns(comp.node)
 
-nodeof(xml::EzXML.Document) = root(xml)
-nodeof(node::EzXML.Node) = node
+nodeof(xml) = applicable(hasroot, xml) ? root(xml) : xml
 nodeof(comp::Component) = comp.node
 
 """
@@ -34,8 +33,6 @@ end
 """
     list_initiated_variables returns all variables that have an initial_value
 """
-# list_initiated_variables(xml::EzXML.Document) = findall("//x:component/x:variable[@initial_value]", root(xml), ["x"=>cellml_ns(xml)])
-
 function list_initiated_variables(comp::Component)
     return findall("./x:variable[@initial_value]", nodeof(comp), ["x" => cellml_ns(comp)])
 end
@@ -159,6 +156,6 @@ function list_encapsulation(doc, comp)
                 return nodes
             end
         end
-        return EzXML.Node[]
+        return Any[]
     end
 end

--- a/src/components.jl
+++ b/src/components.jl
@@ -1,5 +1,4 @@
-const cellml_ns(xml::EzXML.Document) = namespace(root(xml))
-const cellml_ns(node::EzXML.Node) = namespace(node)
+const cellml_ns(xml) = namespace(nodeof(xml))
 const mathml_ns = "http://www.w3.org/1998/Math/MathML"
 
 create_var(x) = unwrap((@variables $x)[1])
@@ -12,7 +11,7 @@ end
 
 to_symbol(x::Symbol) = x
 to_symbol(x::AbstractString) = Symbol(x)
-to_symbol(x::EzXML.Node) = Symbol(x["name"])
+to_symbol(x) = Symbol(x["name"])
 to_symbol(comp::Component) = comp.name
 
 """

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -5,7 +5,7 @@ end
 
 struct Component
     name::Symbol
-    node::EzXML.Node
+    node
     deps::Set{Symbol}
 end
 
@@ -22,7 +22,7 @@ variables(conn::Connection) = conn.vars
 
 struct Document
     path::AbstractString
-    xmls::Array{EzXML.Document}
+    xmls::Vector
     comps::Array{Component}
     conns::Array{Connection}
 end

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -1,0 +1,13 @@
+using CellMLToolkit, ModelingToolkit, Test
+
+@testset "CellModel ModelingToolkit interface" begin
+    model_path = joinpath(pkgdir(CellMLToolkit), "models", "lorenz.cellml.xml")
+    model = CellMLToolkit.CellModel(model_path)
+
+    # Exercise the CellModel extension only through ModelingToolkit's public generic.
+    problem = ModelingToolkit.ODEProblem(model, (0.0, 1.0))
+
+    @test problem.f.sys === CellMLToolkit.getsys(model)
+    @test !isempty(CellMLToolkit.list_states(model))
+    @test !isempty(CellMLToolkit.list_params(model))
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,16 +1,3 @@
-using SciMLTesting, CellMLToolkit, Test
+using SciMLTesting, CellMLToolkit
 
-run_qa(
-    CellMLToolkit;
-    reexports_allow = (:ODEProblem, :readxml),
-    api_docs_kwargs = (; rendered_ignore = (:ODEProblem, :readxml)),
-    aqua_kwargs = (; ambiguities = (; recursive = false)),
-    ei_kwargs = (;
-        all_qualified_accesses_are_public = (;
-            ignore = (
-                :Document,      # EzXML (not declared public)
-                :Node,          # EzXML (not declared public)
-            ),
-        ),
-    ),
-)
+run_qa(CellMLToolkit)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- replace repository-specific QA exceptions with plain `run_qa(CellMLToolkit)`
- remove `ODEProblem` and `readxml` reexports, document the `ModelingToolkit.ODEProblem(::CellModel, ...)` extension at its definition site, and use owner-module calls in docs
- remove EzXML private-type dependencies, enable doctests and exported API checks, and add a generic-only ModelingToolkit interface test
- bump to 3.0.0 because removing public reexports is breaking

## Validation
- Julia 1.12 `Pkg.test()`: passed (`beeler` 4/4, `interfaces` 3/3, `noble_1962` 3/3)
- strict plain SciMLTesting 2.4 QA: 20/20 passed
- Documenter doctests, `checkdocs = :exports`, and HTML rendering passed
- Runic and `git diff --check` passed
- no tracked `Project.toml` source paths