### PR TITLE
Fix docs build: align CellMLToolkit compat with v2

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,6 +4,6 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
-CellMLToolkit = "3"
+CellMLToolkit = "2"
 Documenter = "1"
 ModelingToolkit = "11.21"


### PR DESCRIPTION
## Summary
- Fixes Documentation CI failure during `Pkg.develop` / `Pkg.instantiate`.
- `docs/Project.toml` required `CellMLToolkit = "3"` while the package is still on 2.x (currently v2.19.0), causing an empty compat intersection.

## Test plan
- [x] Reproduced CI failure locally (`empty intersection between CellMLToolkit@2.19.0 and project compatibility 3`)
- [x] Verified `julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'` succeeds after the fix
- [ ] Documentation CI passes on this PR


Made with [Cursor](https://cursor.com)