### PR TITLE
MTK guesses for variable definition

### DIFF
--- a/src/CellMLToolkit.jl
+++ b/src/CellMLToolkit.jl
@@ -7,7 +7,7 @@ using SymbolicUtils: SymbolicUtils, operation, unwrap
 using ModelingToolkit: ModelingToolkit, @parameters, @variables, Differential,
     Equation, ODEProblem, System,
     equations, parameters, mtkcompile,
-    substitute, unknowns, initial_conditions
+    substitute, unknowns, initial_conditions, guesses
 using ModelingToolkitBase: isparameter
 using Setfield: @set!
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -257,7 +257,7 @@ function process_components(doc::Document; simplify = true)
         # the system
         @set! sys.initial_conditions = merge(
             Dict{Any, Any}(initial_conditions(sys)),
-            Dict{Any, Any}(find_list_value(doc, vcat(parameters(sys), unknowns(sys))))
+            Dict{Any, Any}(find_list_value(doc, vcat(parameters(sys), unknowns(sys)), guesses(sys)))
         )
     end
 
@@ -336,10 +336,10 @@ function split_sym(sym)
     return make_var(split(s, "₊")...)
 end
 
-find_sys_p(doc::Document, sys) = find_list_value(doc, parameters(sys))
-find_sys_u0(doc::Document, sys) = find_list_value(doc, unknowns(sys))
+find_sys_p(doc::Document, sys) = find_list_value(doc, parameters(sys), guesses(sys))
+find_sys_u0(doc::Document, sys) = find_list_value(doc, unknowns(sys), guesses(sys))
 
-function find_list_value(doc::Document, names)
+function find_list_value(doc::Document, names, source_map=nothing)
     vars, syms = collect_initiated_values(doc)
     varkeys = Set(keys(vars))
     groups = find_equivalence_groups(doc)
@@ -347,7 +347,8 @@ function find_list_value(doc::Document, names)
     vals = []
 
     for x in names
-        u = split_sym(x)
+        source = isnothing(source_map) ? x : get(source_map, x, x)
+        u = split_sym(source)
         u = haskey(syms, u) ? syms[u] : u
         var = groups[u] ∩ varkeys
         if length(var) == 0

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -11,3 +11,11 @@ using CellMLToolkit, ModelingToolkit, Test
     @test !isempty(CellMLToolkit.list_states(model))
     @test !isempty(CellMLToolkit.list_params(model))
 end
+
+@testset "MTK generated initial-value parameter provenance" begin
+    model_path = joinpath(pkgdir(CellMLToolkit), "models", "ohara_rudy_cipa_v1_2017.cellml.xml")
+    model = CellMLToolkit.CellModel(model_path)
+
+    @test !isempty(CellMLToolkit.list_params(model))
+    @test !isempty(ModelingToolkit.analytically_integrated(CellMLToolkit.getsys(model)))
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This fixes #190. The problem is that the cellml model contains `D(IKr.D)~0`, which since MTK@11.32 is transformed into an analytically integrated variable and introduces a new parameter, `IKr.D#0(time)` to represent its initial condition. CellMLToolkit is unable to find a value for this new parameter and so it errors. 

The new functionality tries to use the MTK provided guesses (which includes a guess for `IKr.D#0(time)~IKr.D`) to figure out a suitable initial value for `IKr.D#0(time)`. Any variables that don't have a guess are handled the same. Any variables that do have a guess will use that guess