### PR TITLE
Format CellML guesses with Runic

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -339,7 +339,7 @@ end
 find_sys_p(doc::Document, sys) = find_list_value(doc, parameters(sys), guesses(sys))
 find_sys_u0(doc::Document, sys) = find_list_value(doc, unknowns(sys), guesses(sys))
 
-function find_list_value(doc::Document, names, source_map=nothing)
+function find_list_value(doc::Document, names, source_map = nothing)
     vars, syms = collect_initiated_values(doc)
     varkeys = Set(keys(vars))
     groups = find_equivalence_groups(doc)


### PR DESCRIPTION
## What changed and why

Reformats one continued expression in `src/components.jl` so current CellMLToolkit master passes its Runic check. The drift was introduced in https://github.com/SciML/CellMLToolkit.jl/pull/200, and the same line still fails Runic v1.10 on current upstream commit https://github.com/SciML/CellMLToolkit.jl/commit/32195dd975c77a74c59a35bd1823fd0bb4618912.

This is a mechanical formatting-only change. Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before on unmodified upstream commit `32195dd975c77a74c59a35bd1823fd0bb4618912`:

```text
julia +1.12 --startup-file=no --project=@runic -m Runic --check components.jl
runic_base_exit=1
```

Passing after:

```text
julia +1.12 --startup-file=no --project=@runic -m Runic --check .
exit 0

git diff --check
exit 0

typos src/components.jl
exit 0

GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA/qa.jl | 20 passed / 20 total
Testing CellMLToolkit tests passed

GROUP=Core julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Core/beeler.jl | 4 passed / 4 total
Core/interfaces.jl | 5 passed / 5 total
Core/noble_1962.jl | 3 passed / 3 total
Core/precompile_workload.jl | 3 passed / 3 total
Testing CellMLToolkit tests passed
```

## Not verified

No GPU-specific or downstream-package jobs were run locally. Documentation was not built because this changes neither documentation, docstrings, nor public API.

## Links

- Formatting regression source: https://github.com/SciML/CellMLToolkit.jl/pull/200
- Validated upstream base: https://github.com/SciML/CellMLToolkit.jl/commit/32195dd975c77a74c59a35bd1823fd0bb4618912

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
