### PR TITLE
test: exercise generated parameters through ODEProblem

### DIFF
--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -15,7 +15,8 @@ end
 @testset "MTK generated initial-value parameter provenance" begin
     model_path = joinpath(pkgdir(CellMLToolkit), "models", "ohara_rudy_cipa_v1_2017.cellml.xml")
     model = CellMLToolkit.CellModel(model_path)
+    problem = ModelingToolkit.ODEProblem(model, (0.0, 1.0))
 
     @test !isempty(CellMLToolkit.list_params(model))
-    @test !isempty(ModelingToolkit.analytically_integrated(CellMLToolkit.getsys(model)))
+    @test !isempty(problem.p)
 end


### PR DESCRIPTION
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed and why

The generated initial-value regression test called `ModelingToolkit.analytically_integrated`, which is absent from a supported downgraded dependency combination (ModelingToolkit 11.23.0 and ModelingToolkitBase 1.32.0). The test now verifies the public behavior the CellML fix provides: the O'Hara-Rudy model constructs successfully as an `ODEProblem` with nonempty parameters.

This keeps the test effective without raising package compat solely for a test-only accessor. With the source portion of the original fix removed, the revised test still fails while constructing the model with the generated `IKr.D#0` parameter.

## Failing before

On unmodified master `3fc0cfbe510a849dbb960a5bb62f4b6fe3b1897f`, Julia 1.10.12 with ModelingToolkit 11.23.0 and ModelingToolkitBase 1.32.0:

```text
MTK generated initial-value parameter provenance: Error During Test
  Expression: !(isempty(ModelingToolkit.analytically_integrated(CellMLToolkit.getsys(model))))
  UndefVarError: `analytically_integrated` not defined
Test Summary:      | Pass  Error  Total
Core/interfaces.jl |    4      1      5
```

A clean `git bisect` between `3fc15526f843bd83c0e104744ab1ec3bc4f9ea47` and master identified `abc1a2ed3d291406fd53406d819742b8007f694a` as the first bad commit.

## Passing after

The same downgraded environment and Core command now reports:

```text
Test Summary:      | Pass  Total
Core/interfaces.jl |    5      5
Test Summary:               | Pass  Total
Core/precompile_workload.jl |    3      3
Testing CellMLToolkit tests passed
```

To ensure the replacement did not weaken the original regression, I applied the revised test to the parent of the source fix with current dependencies. It fails as intended:

```text
KeyError: key CellMLToolkit.Var(Symbol("var\"IKr"), Symbol("D#0\"")) not found
  [2] find_list_value(...)
      @ CellMLToolkit src/components.jl:352
Test Summary:                                    | Error  Total
MTK generated initial-value parameter provenance |     1      1
```

## Verification

- `GROUP=Core julia +1.10.12 --project -e 'using Pkg; Pkg.test()'` with ModelingToolkit 11.23.0 / ModelingToolkitBase 1.32.0: 15/15 passed.
- Same command with current compatible dependencies (ModelingToolkit 11.40.0 / ModelingToolkitBase 1.68.2): 15/15 passed.
- `GROUP=Core julia +1.12.6 --project -e 'using Pkg; Pkg.test()'`: 15/15 passed.
- `GROUP=QA julia +1.10.12 --project -e 'using Pkg; Pkg.test()'`: 18/18 passed.
- Runic 1.10.0 check on `test/interfaces.jl`: passed.
- `typos .`: passed.
- `git diff --check`: passed.

I did not run `GROUP=Everything`. I did not build docs because this changes only a test and touches no public API, docstring, or documentation source.

## Reviewer note

The test intentionally checks `ODEProblem` construction and its parameter container instead of an alias-elimination implementation detail. This is the cross-version observable behavior that failed before the original generated-parameter source fix.

## Links

- Original failing CI job: https://github.com/SciML/CellMLToolkit.jl/actions/runs/33390921446/job/99484098361
- Introducing commit: https://github.com/SciML/CellMLToolkit.jl/commit/abc1a2ed3d291406fd53406d819742b8007f694a
- Introducing PR: https://github.com/SciML/CellMLToolkit.jl/pull/200

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
