### PR TITLE
Release CellMLToolkit 2.19.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CellMLToolkit"
 uuid = "03cb29e0-1ef4-4721-aa24-cf58a006576f"
 authors = ["Shahriar Iravanian <siravan@svtsim.com>"]
-version = "2.19.1"
+version = "2.19.2"
 
 [deps]
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"


### PR DESCRIPTION
Bumps `CellMLToolkit` 2.19.1 -> 2.19.2 (patch).

Source files changed since 2.19.1:
- `src/components.jl`

Commits:
- Source changes in src/components.jl

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
