### PR TITLE
Require Symbolics 7.39.2 (32-bit hasha_seed)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [compat]
+Symbolics = "7.39.2"
 EzXML = "1.1"
 MathML = "0.1.19"
 Memoize = "0.4.2"
@@ -31,6 +32,7 @@ Test = "1.10"
 julia = "1.10"
 
 [extras]
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
@@ -40,4 +42,4 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ModelingToolkit", "OrdinaryDiffEq", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqSDIRK", "SafeTestsets", "SciMLTesting"]
+test = ["Symbolics", "Test", "ModelingToolkit", "OrdinaryDiffEq", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqSDIRK", "SafeTestsets", "SciMLTesting"]


### PR DESCRIPTION
## Summary
Force Symbolics ≥7.39.2 so x86 resolves SymbolicUtils ≥4.46.4 (hasha_seed).

## Test plan
- [ ] x86 Core green

Made with [Cursor](https://cursor.com)