### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: ""
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,25 @@
+using CellMLToolkit, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+models_dir = joinpath(@__DIR__, "..", "models")
+
+# =============================================================================
+# CellML model loading / ODE system generation
+# =============================================================================
+
+SUITE["load"] = BenchmarkGroup()
+
+SUITE["load"]["beeler_reuter"] = @benchmarkable CellModel(
+    joinpath($models_dir, "beeler_reuter_1977.cellml.xml")
+)
+SUITE["load"]["lorenz"] = @benchmarkable CellModel(
+    joinpath($models_dir, "lorenz.cellml.xml")
+)
+
+ml = CellModel(joinpath(models_dir, "lorenz.cellml.xml"))
+ml_beeler = CellModel(joinpath(models_dir, "beeler_reuter_1977.cellml.xml"))
+
+SUITE["load"]["getsys"] = @benchmarkable getsys($ml)
+SUITE["load"]["list_states"] = @benchmarkable list_states($ml_beeler)
+SUITE["load"]["list_params"] = @benchmarkable list_params($ml_beeler)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~31s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~31s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md